### PR TITLE
Drop docs from published gem

### DIFF
--- a/nutanix_vmm.gemspec
+++ b/nutanix_vmm.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
     ls.readlines("\x0", chomp: true).reject do |f|
       (f == gemspec) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
+        f.start_with?(*%w[bin/ docs/ test/ spec/ features/ .git .github appveyor Gemfile])
     end
   end
   s.executables   = s.files.grep(%r{\Aexe/}) { |f| File.basename(f) }


### PR DESCRIPTION
@agrare Please review. This saves about 3.3MB of disk space.

Part of https://github.com/ManageIQ/manageiq-pods/issues/736